### PR TITLE
GetNeedDivisor and Update Need

### DIFF
--- a/src/Needs/NeedBase.h
+++ b/src/Needs/NeedBase.h
@@ -65,9 +65,9 @@ public:
 		}
 	}
 
-	virtual float GetNeedDivisor(){};
+	virtual float GetNeedDivisor() = 0;
 
-	virtual void UpdateNeed(){};
+	virtual void UpdateNeed() = 0;
 
 	virtual void InitializeNeed()
 	{


### PR DESCRIPTION
Set the GetNeedDivisor and UpdateNeed methods equal to zero so that they are purely virtual.