### PR TITLE
Added disable fast travel

### DIFF
--- a/src/Events.h
+++ b/src/Events.h
@@ -225,7 +225,7 @@ namespace Events
 
 		RE::BSEventNotifyControl ProcessEvent([[maybe_unused]] const RE::TESHitEvent* a_event, [[maybe_unused]] RE::BSTEventSource<RE::TESHitEvent>* a_eventSource) override
 		{
-			if (!a_event || !a_event->target || !a_event->target->IsPlayerRef() || !a_event->cause ) {
+			if (!a_event || !a_event->target || !a_event->target->IsPlayerRef() || !a_event->cause) {
 				return RE::BSEventNotifyControl::kContinue;
 			}
 
@@ -238,7 +238,7 @@ namespace Events
 					ProcessOnHitEvent(causeActor);
 				}
 			}
-			return RE::BSEventNotifyControl::kContinue;	
+			return RE::BSEventNotifyControl::kContinue;
 		}
 
 		static void Register()
@@ -259,7 +259,7 @@ namespace Events
 			return &singleton;
 		}
 
-		RE::BSEventNotifyControl ProcessEvent([[maybe_unused]] const RE::TESMagicEffectApplyEvent* a_event, [[maybe_unused]] RE::BSTEventSource<RE::TESMagicEffectApplyEvent>* a_eventSource) override
+		RE::BSEventNotifyControl ProcessEvent(const RE::TESMagicEffectApplyEvent* a_event, [[maybe_unused]] RE::BSTEventSource<RE::TESMagicEffectApplyEvent>* a_eventSource) override
 		{
 			if (!a_event || !a_event->target || !a_event->target->IsPlayerRef()) {
 				return RE::BSEventNotifyControl::kContinue;
@@ -284,6 +284,41 @@ namespace Events
 		}
 	};
 
+	class OnMenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+
+		static OnMenuOpenCloseEventHandler* GetSingleton()
+		{
+			static OnMenuOpenCloseEventHandler singleton;
+			return &singleton;
+		}
+
+		RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>* a_eventSource) override
+		{
+			if (!a_event || !a_eventSource) {
+				return RE::BSEventNotifyControl::kContinue;
+			}
+
+			if(a_event->menuName == RE::MapMenu::MENU_NAME) {
+				if (a_event->opening && Utility::IsFastTravelEnabled() && Utility::DisableFTCheck()) {
+					Utility::EnableFastTravel(false);
+				} else if (!a_event->opening) {
+					Utility::EnableFastTravel(true);	
+				}
+			}
+			
+			return RE::BSEventNotifyControl::kContinue;
+		}
+
+		static void Register()
+		{
+			if (const auto ui = Utility::GetUI()) {
+				ui->AddEventSink<RE::MenuOpenCloseEvent>(OnMenuOpenCloseEventHandler::GetSingleton());
+			}
+		}
+	};
+
 	inline static void Register()
 	{
 		OnSleepStartEventHandler::Register();
@@ -291,5 +326,6 @@ namespace Events
 		OnEquipEventHandler::Register();
 		OnHitEventHandler::Register();
 		OnEffectApplyEventHandler::Register();
+		OnMenuOpenCloseEventHandler::Register();
 	}
 }

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -5,8 +5,11 @@
 namespace Hooks
 {
 	inline static REL::Relocation<std::uintptr_t> On_Update_Hook{ REL::RelocationID(35565, 36564), REL::Relocate(0x1E, 0x6E) };
+	inline static REL::Relocation<std::uintptr_t> Fast_Travel_Message_Hook { REL::RelocationID(39372, 40444), REL::Relocate(0x176, 0x18B) };
+
 
 	inline void Install() {
 		SurvivalMode::InstallUpdateHook();
+		SurvivalMode::InstallFtMessageHook();
 	}
 }

--- a/src/Settings/FormLoader.h
+++ b/src/Settings/FormLoader.h
@@ -48,8 +48,6 @@ public:
 		logger::info("All forms are loaded.");
 		LoadCompatibilityForms(dataHandler);
 		logger::info("Compatibility forms are loaded.");
-		CacheGameAddresses();
-		logger::info("Cached addresses");
 	}
 
 	void LoadHungerForms(RE::TESDataHandler* dataHandler)
@@ -344,6 +342,7 @@ public:
 		inJail->data.flags.opCode = RE::CONDITION_ITEM_DATA::OpCode::kGreaterThan;
 
 		utility->IsInJailCondition = inJail;
+
 	}
 
 	void LoadCompatibilityForms(RE::TESDataHandler* dataHandler)
@@ -441,5 +440,7 @@ public:
 		utility->MenuControlsSingletonAddress = RELOCATION_ID(515124, 401263).address();
 		utility->GetWarmthRatingAddress = RELOCATION_ID(25834, 26394).address();
 		utility->DoCombatSpellApplyAddress = RELOCATION_ID(37666, 38620).address();
+		utility->EnableFtAddress = RELOCATION_ID(54946, 55563).address();
+		utility->IsFtEnabledAddress = RELOCATION_ID(54848, 55481).address();
 	}
 };

--- a/src/SurvivalMode.cpp
+++ b/src/SurvivalMode.cpp
@@ -93,6 +93,21 @@ bool SurvivalMode::InstallUpdateHook()
 	return true;
 }
 
+bool SurvivalMode::InstallFtMessageHook()
+{
+	auto& trampoline = SKSE::GetTrampoline();
+	_OverwriteFastTravelMessage = trampoline.write_call<5>(Hooks::Fast_Travel_Message_Hook.address(), OverwriteFastTravelMessage);
+	logger::info("Installed ft message hook");
+	return true;
+}
+
+void SurvivalMode::OverwriteFastTravelMessage(const char* a_notification, const char* a_soundToPlay, bool a_cancelIfAlreadyQueued)
+{
+	if (!Utility::GetUI()->IsMenuOpen(RE::MapMenu::MENU_NAME) || !Utility::DisableFTCheck()) {
+		_OverwriteFastTravelMessage(a_notification, a_soundToPlay, a_cancelIfAlreadyQueued);
+	}
+}
+
 void SurvivalMode::AddPlayerSpellPerks() 
 {
 	logger::info("Adding perks");

--- a/src/SurvivalMode.h
+++ b/src/SurvivalMode.h
@@ -7,12 +7,17 @@ class SurvivalMode
 {
 public:
 	static bool InstallUpdateHook();
-	inline static std::int32_t OnUpdate(std::int64_t a1);
-	inline static REL::Relocation<decltype(OnUpdate)> _OnUpdate;
+	static bool InstallFtMessageHook();
 	inline static void StartSurvivalMode();
 	inline static void StopSurvivalMode();
 
 protected:
+	inline static std::int32_t OnUpdate(std::int64_t a1);
+	inline static REL::Relocation<decltype(OnUpdate)> _OnUpdate;
+
+	inline static void OverwriteFastTravelMessage(const char* a_notification, const char* a_soundToPlay = 0, bool a_cancelIfAlreadyQueued = true);
+	inline static REL::Relocation<decltype(OverwriteFastTravelMessage)> _OverwriteFastTravelMessage;
+
 	inline static void SurvivalModeLoopUpdate();
 	inline static void SendAllNeedsUpdate();
 	inline static void StopAllNeeds();

--- a/src/Utility.h
+++ b/src/Utility.h
@@ -65,7 +65,6 @@ public:
 	RE::TESCondition* WTIsInCoolArea;
 	RE::TESCondition* WTIsInFreezingArea;
 
-
 	RE::EffectSetting* WerewolfFeedRestoreHealth;
 	RE::EffectSetting* DA11AbFortifyHealth;
 
@@ -96,6 +95,8 @@ public:
 	uintptr_t MenuControlsSingletonAddress;
 	uintptr_t GetWarmthRatingAddress;
 	uintptr_t DoCombatSpellApplyAddress;
+	uintptr_t EnableFtAddress;
+	uintptr_t IsFtEnabledAddress;
 
 	bool WasInOblivion = false;
 
@@ -217,6 +218,19 @@ public:
 		return false;
 	}
 
+	static bool DisableFTCheck()
+	{
+		if(!Utility::IsOnFlyingMount(Utility::GetPlayer()))
+		{
+			auto enabled = Utility::GetSingleton()->Survival_ModeEnabled->value;
+			if (enabled && enabled == 1.0f) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	static bool PlayerCanGetWellRested()
 	{
 		//Vampire or WW or Lich then false
@@ -318,7 +332,7 @@ public:
 				}
 			}
 		}
-
+		
 		if (adoptionQuest->IsRunning() && (child1Near || child2Near)) {
 			return true;
 		}
@@ -345,7 +359,7 @@ public:
 
 	static bool IsPlayerInDialogue()
 	{
-		return Utility::GetSingleton()->GetUI()->IsMenuOpen("Dialogue Menu");
+		return Utility::GetSingleton()->GetUI()->IsMenuOpen(RE::DialogueMenu::MENU_NAME);
 	}
 
 	static bool IsOnFlyingMount(RE::Actor* a_actor)
@@ -367,5 +381,19 @@ public:
 		using func_t = decltype(&Utility::DoCombatSpellApply);
 		REL::Relocation<func_t> func{ Utility::GetSingleton()->DoCombatSpellApplyAddress };
 		return func(actor, spell, target);
+	}
+
+	static void EnableFastTravel(bool a_enable)
+	{
+		using func_t = decltype(&Utility::EnableFastTravel);
+		REL::Relocation<func_t> func{ Utility::GetSingleton()->EnableFtAddress };
+		return func(a_enable);
+	}
+
+	static bool IsFastTravelEnabled()
+	{
+		using func_t = decltype(&Utility::IsFastTravelEnabled);
+		REL::Relocation<func_t> func{ Utility::GetSingleton()->IsFtEnabledAddress };
+		return func();
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,10 +89,10 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	logger::info("loading SMI");
 
 	SKSE::Init(a_skse);
-	SKSE::AllocTrampoline(14);
+	FormLoader::GetSingleton()->CacheGameAddresses();
+	SKSE::AllocTrampoline(42);
 	Hooks::Install();
 	Events::Register();
-
 	auto messaging = SKSE::GetMessagingInterface();
 	if (!messaging->RegisterListener(InitListener)) {
 		return false;


### PR DESCRIPTION
Added functionality to disable fast travel.
How it works:
Hooks and calls the game function to disable fast travel whenever you open the map. It re-enables it to prevent issues with scripted fast travel events.
It also hooks the function call when the game displays a "You cannot fast travel from here" and keeps that from showing when SM is enabled.